### PR TITLE
fix(action): fix the error when open PowerToys settings

### DIFF
--- a/PowerToysActions.cs
+++ b/PowerToysActions.cs
@@ -60,8 +60,17 @@ public class OpenPowerToysSettingsAction : IAction
     public IEnumerable<string> Keywords { get; init; } = [];
     public void Execute()
     {
-        var appPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "PowerToys\\PowerToys.exe");
-        Process.Start(new ProcessStartInfo(appPath) { Arguments = $"--open-settings={SettingsLinkName}" });
+        var relativePath = "PowerToys\\PowerToys.exe";
+        var appPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), relativePath);
+        if (!File.Exists(appPath))
+        {
+            appPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), relativePath);
+        }
+
+        if (File.Exists(appPath))
+        {
+            Process.Start(new ProcessStartInfo(appPath) { Arguments = $"--open-settings={SettingsLinkName}" });
+        }
     }
 }
 


### PR DESCRIPTION
Resolve: #1, #3

Handle program path variations for PowerToys settings action. Because the machine wide installation package defaults to a different program path.

Refs: https://github.com/microsoft/PowerToys?tab=readme-ov-file#via-github-with-exe-recommended