### PR TITLE
Add internationalization support

### DIFF
--- a/Flow.Launcher.Plugin.PowerToys.csproj
+++ b/Flow.Launcher.Plugin.PowerToys.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Flow.Launcher.Plugin" Version="4.4.0" />
+    <PackageReference Include="Flow.Launcher.Plugin" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Flow.Launcher.Plugin.PowerToys.csproj
+++ b/Flow.Launcher.Plugin.PowerToys.csproj
@@ -26,6 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Flow.Launcher.Localization" Version="0.0.5" />
     <PackageReference Include="Flow.Launcher.Plugin" Version="4.7.0" />
   </ItemGroup>
 
@@ -33,6 +34,21 @@
     <None Update="images\PowerToys.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+	<Content Include="Languages\**">
+		<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</Content>
+  </ItemGroup>
+
+  <ItemGroup>
+	<Content Update="Languages\en.xaml">
+		<Generator>MSBuild:Compile</Generator>
+	</Content>
+    <Content Update="Languages\zh-cn.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Content>
+    <Content Update="Languages\zh-tw.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Content>
   </ItemGroup>
 
 </Project>

--- a/Languages/en.xaml
+++ b/Languages/en.xaml
@@ -1,0 +1,25 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:system="clr-namespace:System;assembly=mscorlib">
+
+	<system:String x:Key="plugin_name">PowerToys</system:String>
+	<system:String x:Key="plugin_description">Launches PowerToys tools</system:String>
+	<system:String x:Key="powertoys_not_running">PowerToys is not running</system:String>
+	<system:String x:Key="powertoys_not_running_subtitle">Make sure PowerToys is installed and running before using this plugin.</system:String>
+	<system:String x:Key="open_settings">Open Settings for this Utility</system:String>
+	<system:String x:Key="run_as_administrator">Run as Administrator</system:String>
+	<system:String x:Key="keywords">Keywords</system:String>
+	<system:String x:Key="settings">Open PowerToys Settings</system:String>
+	<system:String x:Key="screen_ruler">Screen Ruler</system:String>
+	<system:String x:Key="shortcut_guide">Shortcut Guide</system:String>
+	<system:String x:Key="color_picker">Show Color Picker</system:String>
+	<system:String x:Key="always_on_top">Pin Always On Top</system:String>
+	<system:String x:Key="text_extractor">Extract Text</system:String>
+	<system:String x:Key="fancy_zones">Fancy Zones Editor</system:String>
+	<system:String x:Key="hosts_editor">Hosts Editor</system:String>
+	<system:String x:Key="registry_preview">Registry Preview</system:String>
+	<system:String x:Key="workspaces">Workspaces Editor</system:String>
+	<system:String x:Key="crop_and_lock_reparent">Crop And Lock - Reparent</system:String>
+	<system:String x:Key="crop_and_lock_thumbnail">Crop And Lock - Thumbnail</system:String>
+	<system:String x:Key="environment_variables">Environment Variables</system:String>
+</ResourceDictionary>

--- a/Languages/zh-cn.xaml
+++ b/Languages/zh-cn.xaml
@@ -1,0 +1,25 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:system="clr-namespace:System;assembly=mscorlib">
+
+	<system:String x:Key="plugin_name">PowerToys</system:String>
+	<system:String x:Key="plugin_description">启动 PowerToys 工具集</system:String>
+	<system:String x:Key="powertoys_not_running">PowerToys 未在运行中</system:String>
+	<system:String x:Key="powertoys_not_running_subtitle">确保在使用此插件前已安装并运行了 PowerToys。</system:String>
+	<system:String x:Key="open_settings">打开此实用工具的设置</system:String>
+	<system:String x:Key="run_as_administrator">以管理员身份运行</system:String>
+	<system:String x:Key="keywords">关键词</system:String>
+	<system:String x:Key="settings">打开 PowerToys 设置</system:String>
+	<system:String x:Key="screen_ruler">屏幕标尺</system:String>
+	<system:String x:Key="shortcut_guide">快捷键指南</system:String>
+	<system:String x:Key="color_picker">显示颜色选取器</system:String>
+	<system:String x:Key="always_on_top">保持窗口始终置顶</system:String>
+	<system:String x:Key="text_extractor">提取文本</system:String>
+	<system:String x:Key="fancy_zones">FancyZones 编辑器</system:String>
+	<system:String x:Key="hosts_editor">Hosts 编辑器</system:String>
+	<system:String x:Key="registry_preview">注册表预览</system:String>
+	<system:String x:Key="workspaces">工作区编辑器</system:String>
+	<system:String x:Key="crop_and_lock_reparent">窗口裁剪器 - 重定父级</system:String>
+	<system:String x:Key="crop_and_lock_thumbnail">窗口裁剪器 - 缩略图</system:String>
+	<system:String x:Key="environment_variables">环境变量</system:String>
+</ResourceDictionary>

--- a/Languages/zh-tw.xaml
+++ b/Languages/zh-tw.xaml
@@ -1,0 +1,25 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:system="clr-namespace:System;assembly=mscorlib">
+
+	<system:String x:Key="plugin_name">PowerToys</system:String>
+	<system:String x:Key="plugin_description">啟動 PowerToys 工具集</system:String>
+	<system:String x:Key="powertoys_not_running">PowerToys 未在執行中</system:String>
+	<system:String x:Key="powertoys_not_running_subtitle">確保在使用此外掛前已安裝並運行了 PowerToys。</system:String>
+	<system:String x:Key="open_settings">開啟此實用工具的設定</system:String>
+	<system:String x:Key="run_as_administrator">以系統管理員身分執行</system:String>
+	<system:String x:Key="keywords">關鍵詞</system:String>
+	<system:String x:Key="settings">開啟 PowerToys 設定</system:String>
+	<system:String x:Key="screen_ruler">螢幕尺規</system:String>
+	<system:String x:Key="shortcut_guide">快捷鍵指南</system:String>
+	<system:String x:Key="color_picker">顯示顏色選擇器</system:String>
+	<system:String x:Key="always_on_top">保持視窗始終置頂</system:String>
+	<system:String x:Key="text_extractor">擷取文字</system:String>
+	<system:String x:Key="fancy_zones">FancyZones 編輯器</system:String>
+	<system:String x:Key="hosts_editor">主機檔案編輯器</system:String>
+	<system:String x:Key="registry_preview">登錄預覽</system:String>
+	<system:String x:Key="workspaces">工作區編輯器</system:String>
+	<system:String x:Key="crop_and_lock_reparent">裁剪和鎖定 - 重定父級</system:String>
+	<system:String x:Key="crop_and_lock_thumbnail">裁剪和鎖定 - 縮圖</system:String>
+	<system:String x:Key="environment_variables">環境變數</system:String>
+</ResourceDictionary>

--- a/Main.cs
+++ b/Main.cs
@@ -20,7 +20,7 @@ public class PowerToys : IAsyncPlugin, IContextMenu, IAsyncReloadable, IPluginI1
     {
         if (!_launcher.IsPowerToysRunning())
         {
-            return [new Result{Title = _context.API.GetTranslation("powertoys_not_running"), SubTitle = _context.API.GetTranslation("powertoys_not_running_subtitle") }];
+            return [new Result{Title = GetTranslation("powertoys_not_running"), SubTitle = GetTranslation("powertoys_not_running_subtitle") }];
         }
         if(string.IsNullOrWhiteSpace(query.Search))
         {

--- a/Main.cs
+++ b/Main.cs
@@ -5,9 +5,9 @@ using System.Threading.Tasks;
 
 namespace Flow.Launcher.Plugin.PowerToys;
 
-public class PowerToys : IAsyncPlugin, IContextMenu, IAsyncReloadable
+public class PowerToys : IAsyncPlugin, IContextMenu, IAsyncReloadable, IPluginI18n
 {
-    private PluginInitContext _context;
+    internal static PluginInitContext _context { get; private set; }
     private PowerToysLauncher _launcher;
     public async Task InitAsync(PluginInitContext context)
     {
@@ -20,7 +20,7 @@ public class PowerToys : IAsyncPlugin, IContextMenu, IAsyncReloadable
     {
         if (!_launcher.IsPowerToysRunning())
         {
-            return [new Result{Title = "PowerToys is not running", SubTitle = "Make sure PowerToys is installed and running before using this plugin."}];
+            return [new Result{Title = _context.API.GetTranslation("powertoys_not_running"), SubTitle = _context.API.GetTranslation("powertoys_not_running_subtitle") }];
         }
         if(string.IsNullOrWhiteSpace(query.Search))
         {
@@ -34,12 +34,13 @@ public class PowerToys : IAsyncPlugin, IContextMenu, IAsyncReloadable
         return new List<Result>();
     }
 
-    private static Result MapActionToResult(IAction action)
+    private Result MapActionToResult(IAction action)
     {
         return new Result
         {
             Action =  _ =>  { action.Execute(); return true; },
-            Title = action.Title,
+            Title = GetTranslation(action.TitleKey),
+            SubTitle = action.Keywords.Any() ? GetTranslation("keywords") + ": " + string.Join(" ", action.Keywords) : string.Empty,
             IcoPath = action.Icon,
             ContextData = action
         };
@@ -54,5 +55,20 @@ public class PowerToys : IAsyncPlugin, IContextMenu, IAsyncReloadable
     public async Task ReloadDataAsync()
     {
         await _launcher.ApplySettings();
+    }
+
+    public string GetTranslatedPluginTitle()
+    {
+        return GetTranslation("plugin_name");
+    }
+
+    public string GetTranslatedPluginDescription()
+    {
+        return GetTranslation("plugin_description");
+    }
+
+    public string GetTranslation(string key)
+    {
+        return _context.API.GetTranslation(key);
     }
 }

--- a/Main.cs
+++ b/Main.cs
@@ -42,7 +42,7 @@ public class PowerToys : IAsyncPlugin, IContextMenu, IAsyncReloadable, IPluginI1
         {
             Action =  _ =>  { action.Execute(); return true; },
             Title = GetTranslation(action.TitleKey),
-            SubTitle = action.Keywords.Any() ? GetTranslation("keywords") + ": " + string.Join(" ", action.Keywords) : string.Empty,
+            SubTitle = action.Keywords.Any() ? $"{GetTranslation("keywords")}: {string.Join(" ", action.Keywords)}" : string.Empty,
             IcoPath = action.Icon,
             ContextData = action
         };

--- a/Main.cs
+++ b/Main.cs
@@ -26,7 +26,9 @@ public class PowerToys : IAsyncPlugin, IContextMenu, IAsyncReloadable, IPluginI1
         {
             return _launcher.EnabledActions.Select(MapActionToResult).ToList();
         }
-        var filteredResults = _launcher.EnabledActions.Where(x => x.Keywords.Any(y => y.Contains(query.Search.ToLower())));
+        // Split search string, segment by spaces (ignore empty string)
+        var searchTerms = query.Search.ToLower().Split([" "], System.StringSplitOptions.RemoveEmptyEntries);
+        var filteredResults = _launcher.EnabledActions.Where(x => searchTerms.All(term => x.Keywords.Any(keyword => keyword.Contains(term))));
         if(filteredResults.Any())
         {
             return filteredResults.Select(MapActionToResult).ToList();

--- a/PowerToysActions.cs
+++ b/PowerToysActions.cs
@@ -60,8 +60,17 @@ public class OpenPowerToysSettingsAction : IAction
     public IEnumerable<string> Keywords { get; init; } = [];
     public void Execute()
     {
-        var appPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "PowerToys\\PowerToys.exe");
-        Process.Start(new ProcessStartInfo(appPath) { Arguments = $"--open-settings={SettingsLinkName}" });
+        var relativePath = "PowerToys\\PowerToys.exe";
+        var appPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), relativePath);
+        if (!File.Exists(appPath))
+        {
+            appPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), relativePath);
+        }
+
+        if (File.Exists(appPath))
+        {
+            Process.Start(new ProcessStartInfo(appPath) { Arguments = $"--open-settings={SettingsLinkName}" });
+        }
     }
 }
 

--- a/PowerToysActions.cs
+++ b/PowerToysActions.cs
@@ -10,7 +10,7 @@ namespace Flow.Launcher.Plugin.PowerToys;
 
 public interface IAction
 {
-    string Title { get; }
+    string TitleKey { get; }
     IEnumerable<string> Keywords { get; }
     string Icon { get; }
     void Execute();
@@ -21,7 +21,7 @@ public class PowerToysUtilityAction : IAction
 {
     public IEnumerable<string> Keywords { get; init; } = [];
     public required string EventKey { get; init; }
-    public required string Title { get; init; }
+    public required string TitleKey { get; init; }
     
     public string Icon { get; init; } = "";
     public virtual void Execute()
@@ -45,7 +45,7 @@ public class PowerToysUtilityActionWithSettings : PowerToysUtilityAction
     {
         return base.GetContextMenuActions().Concat([
             new OpenPowerToysSettingsAction
-                { Title = "Open Settings for this Utility", Icon = Icon, SettingsLinkName = SettingsLinkName }
+                { TitleKey = "open_settings", Icon = Icon, SettingsLinkName = SettingsLinkName }
         ]);
     }
 }
@@ -53,7 +53,7 @@ public class PowerToysUtilityActionWithSettings : PowerToysUtilityAction
 public class OpenPowerToysSettingsAction : IAction
 {
     public required string SettingsLinkName { get; init; }
-    public required string Title { get; init; }
+    public required string TitleKey { get; init; }
     public string Icon { get; init; } = "";
     public IEnumerable<IAction> GetContextMenuActions() => [];
 
@@ -93,7 +93,7 @@ public class PowerToysUtilityActionWithAsAdmin : PowerToysUtilityActionWithSetti
     public override IEnumerable<IAction> GetContextMenuActions()
     {
         return base.GetContextMenuActions().Concat([
-            new PowerToysUtilityAction { EventKey = RunAsAdminEventKey, Title = "Run as Administrator", Icon = Icon }
+            new PowerToysUtilityAction { EventKey = RunAsAdminEventKey, TitleKey = "run_as_administrator", Icon = Icon }
         ]);
     }
 }

--- a/PowerToysLauncher.cs
+++ b/PowerToysLauncher.cs
@@ -71,7 +71,7 @@ public class PowerToysLauncher
         {
             EventKey = Events.MeasureToolTriggerEvent,
             Keywords = ["measure", "tool", "screen", "ruler"],
-            Title = "Screen Ruler",
+            TitleKey = "screen_ruler",
             Icon = Icons.ScreenRuler,
             SettingsLinkName = "MeasureTool",
             SettingsEnabledNameOverride = "Measure Tool"
@@ -80,7 +80,7 @@ public class PowerToysLauncher
         {
             EventKey = Events.ShortcutGuideTriggerEvent,
             Keywords = ["shortcut", "guide"],
-            Title = "Shortcut Guide",
+            TitleKey = "shortcut_guide",
             Icon = Icons.ShortcutGuide,
             SettingsLinkName = "ShortcutGuide",
             SettingsEnabledNameOverride = "Shortcut Guide"
@@ -89,7 +89,7 @@ public class PowerToysLauncher
         {
             EventKey = Events.ShowColorPickerSharedEvent,
             Keywords = ["color", "colour", "picker"],
-            Title = "Show Color Picker",
+            TitleKey = "color_picker",
             Icon = Icons.ColorPicker,
             SettingsLinkName = "ColorPicker"
         },
@@ -97,7 +97,7 @@ public class PowerToysLauncher
         {
             EventKey = Events.AlwaysOnTopPinEvent,
             Keywords = ["pin", "always", "top"],
-            Title = "Pin Always On Top",
+            TitleKey = "always_on_top",
             Icon = Icons.AlwaysOnTop,
             SettingsLinkName = "AlwaysOnTop"
         },
@@ -105,7 +105,7 @@ public class PowerToysLauncher
         {
             EventKey = Events.ShowPowerOcrEvent,
             Keywords = ["ocr", "text", "extract"],
-            Title = "Extract Text",
+            TitleKey = "text_extractor",
             Icon = Icons.TextExtractor,
             SettingsLinkName = "PowerOcr",
             SettingsEnabledNameOverride = "TextExtractor"
@@ -114,7 +114,7 @@ public class PowerToysLauncher
         {
             EventKey = Events.FZEToggleEvent,
             Keywords = ["fancy", "zones"],
-            Title = "Fancy Zones Editor",
+            TitleKey = "fancy_zones",
             Icon = Icons.FancyZones,
             SettingsLinkName = "FancyZones"
         },
@@ -122,7 +122,7 @@ public class PowerToysLauncher
         {
             EventKey = Events.ShowHostsSharedEvent,
             Keywords = ["hosts"],
-            Title = "Hosts Editor",
+            TitleKey = "hosts_editor",
             Icon = Icons.Hosts,
             SettingsLinkName = "Hosts",
             RunAsAdminEventKey = Events.ShowHostsAdminEvent
@@ -131,7 +131,7 @@ public class PowerToysLauncher
         {
             EventKey = Events.RegistryPreviewTriggerEvent,
             Keywords = ["registry", "preview"],
-            Title = "Registry Preview",
+            TitleKey = "registry_preview",
             Icon = Icons.RegistryPreview,
             SettingsLinkName = "RegistryPreview"
         },
@@ -139,7 +139,7 @@ public class PowerToysLauncher
         {
             EventKey = Events.LaunchWorkspacesEditorEvent,
             Keywords = ["workspaces"],
-            Title = "Workspaces Editor",
+            TitleKey = "workspaces",
             Icon = Icons.Workspaces,
             SettingsLinkName = "Workspaces"
         },
@@ -147,7 +147,7 @@ public class PowerToysLauncher
         {
             EventKey = Events.CropAndLockReparentEvent,
             Keywords = ["crop", "lock", "reparent"],
-            Title = "Crop And Lock - Reparent",
+            TitleKey = "crop_and_lock_reparent",
             Icon = Icons.CropAndLock,
             SettingsLinkName = "CropAndLock"
         },
@@ -155,7 +155,7 @@ public class PowerToysLauncher
         {
             EventKey = Events.CropAndLockThumbnailEvent,
             Keywords = ["crop", "lock", "thumbnail"],
-            Title = "Crop And Lock - Thumbnail",
+            TitleKey = "crop_and_lock_thumbnail",
             Icon = Icons.CropAndLock,
             SettingsLinkName = "CropAndLock"
         },
@@ -163,7 +163,7 @@ public class PowerToysLauncher
         {
             EventKey = Events.ShowEnvironmentVariablesSharedEvent,
             Keywords = ["environment", "variable"],
-            Title = "Environment Variables",
+            TitleKey = "environment_variables",
             Icon = Icons.EnvironmentVariables,
             SettingsLinkName = "EnvironmentVariables",
             RunAsAdminEventKey = Events.ShowEnvironmentVarablesAdminEvent
@@ -173,7 +173,7 @@ public class PowerToysLauncher
             Icon = Icons.PowerToys,
             Keywords = ["settings"],
             SettingsLinkName = "PowerToys",
-            Title = "Open PowerToys Settings"
+            TitleKey = "settings"
         }
     ];
 }

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
     "Name": "PowerToys",
     "Description": "Launches PowerToys tools",
     "Author": "PederBirk",
-    "Version": "1.0.0",
+    "Version": "1.1.0",
     "Language": "csharp",
     "Website": "https://github.com/PederBirk/Flow.Launcher.Plugin.PowerToys",
     "IcoPath": "images/PowerToys.png",


### PR DESCRIPTION
## Major changes

- Implement the [IPluginI18n](https://www.flowlauncher.com/docs/#/API-Reference/Flow.Launcher.Plugin/IPluginI18n) interface.
- Add support for Simplified Chinese(`Languages/zh-cn.xaml`) and Traditional Chinese(`Languages/zh-tw.xaml`).
- `SubTitle` (content is concatenated by keywords of actions) are additionally displayed in the results, so that you can know the search terms of actions in other language environments.

## Other improvements

- The search string supports multiple space-separated words. For example: typing `crop re` now directly retrieves the "Crop And Lock - Reparent" tool.
